### PR TITLE
Add recursive diff for keyed slices and document call structure

### DIFF
--- a/internal/logging/detailed_diff_logger.go
+++ b/internal/logging/detailed_diff_logger.go
@@ -92,6 +92,13 @@ func GetMinimalDifference(diff *manifest.Diff) (interface{}, interface{}) {
 	return computeDiff(prevMap, currMap)
 }
 
+// computeDiff recursively produces minimal prev/curr maps containing only changed fields.
+// Call structure:
+//   - Nested maps: computeDiff recurses directly.
+//   - Slices with a merge key (e.g. "name"): delegates to diffSlices → diffSlicesByKey,
+//     which matches elements by key and calls back into computeDiff per pair.
+//   - Slices without a merge key: treated atomically (full slice returned, no recursion).
+//   - Scalar values: compared with DeepEqual; included only when different.
 func computeDiff(prev, curr map[string]interface{}) (map[string]interface{}, map[string]interface{}) {
 	if prev == nil && curr == nil {
 		return nil, nil
@@ -139,6 +146,18 @@ func computeDiff(prev, curr map[string]interface{}) (map[string]interface{}, map
 				}
 				continue
 			}
+			pSlice, pIsSlice := pVal.([]interface{})
+			cSlice, cIsSlice := cVal.([]interface{})
+			if pIsSlice && cIsSlice {
+				subPrev, subCurr := diffSlices(pSlice, cSlice)
+				if len(subPrev) > 0 {
+					prevResult[key] = subPrev
+				}
+				if len(subCurr) > 0 {
+					currResult[key] = subCurr
+				}
+				continue
+			}
 			if reflect.DeepEqual(pVal, cVal) {
 				continue
 			}
@@ -152,6 +171,103 @@ func computeDiff(prev, curr map[string]interface{}) (map[string]interface{}, map
 	}
 	if len(currResult) == 0 {
 		currResult = nil
+	}
+	return prevResult, currResult
+}
+
+// mergeKeyCandidates lists field names, in priority order, that are treated
+// as natural merge keys for slices of objects. `name` covers the vast
+// majority of Kubernetes keyed lists (containers, env, ports, volumes,
+// volumeMounts, initContainers, ...).
+var mergeKeyCandidates = []string{"name"}
+
+func diffSlices(prev, curr []interface{}) ([]interface{}, []interface{}) {
+	if reflect.DeepEqual(prev, curr) {
+		return nil, nil
+	}
+	if key := findMergeKey(prev, curr); key != "" {
+		return diffSlicesByKey(prev, curr, key)
+	}
+	prevCopy, _ := runtime.DeepCopyJSONValue(prev).([]interface{})
+	currCopy, _ := runtime.DeepCopyJSONValue(curr).([]interface{})
+	return prevCopy, currCopy
+}
+
+func findMergeKey(prev, curr []interface{}) string {
+	if len(prev) == 0 || len(curr) == 0 {
+		return ""
+	}
+	for _, candidate := range mergeKeyCandidates {
+		if allHaveKey(prev, candidate) && allHaveKey(curr, candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func allHaveKey(slice []interface{}, key string) bool {
+	for _, v := range slice {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		if _, exists := m[key]; !exists {
+			return false
+		}
+	}
+	return true
+}
+
+func diffSlicesByKey(prev, curr []interface{}, key string) ([]interface{}, []interface{}) {
+	prevIndex := make(map[string]map[string]interface{}, len(prev))
+	prevOrder := make([]string, 0, len(prev))
+	for _, v := range prev {
+		m := v.(map[string]interface{})
+		k := fmt.Sprint(m[key])
+		if _, seen := prevIndex[k]; !seen {
+			prevOrder = append(prevOrder, k)
+		}
+		prevIndex[k] = m
+	}
+	currIndex := make(map[string]map[string]interface{}, len(curr))
+	currOrder := make([]string, 0, len(curr))
+	for _, v := range curr {
+		m := v.(map[string]interface{})
+		k := fmt.Sprint(m[key])
+		if _, seen := currIndex[k]; !seen {
+			currOrder = append(currOrder, k)
+		}
+		currIndex[k] = m
+	}
+
+	var prevResult, currResult []interface{}
+	for _, k := range prevOrder {
+		pElem := prevIndex[k]
+		cElem, ok := currIndex[k]
+		if !ok {
+			prevResult = append(prevResult, runtime.DeepCopyJSONValue(pElem))
+			continue
+		}
+		subPrev, subCurr := computeDiff(pElem, cElem)
+		if len(subPrev) == 0 && len(subCurr) == 0 {
+			continue
+		}
+		if subPrev == nil {
+			subPrev = map[string]interface{}{}
+		}
+		if subCurr == nil {
+			subCurr = map[string]interface{}{}
+		}
+		subPrev[key] = runtime.DeepCopyJSONValue(pElem[key])
+		subCurr[key] = runtime.DeepCopyJSONValue(cElem[key])
+		prevResult = append(prevResult, subPrev)
+		currResult = append(currResult, subCurr)
+	}
+	for _, k := range currOrder {
+		if _, ok := prevIndex[k]; ok {
+			continue
+		}
+		currResult = append(currResult, runtime.DeepCopyJSONValue(currIndex[k]))
 	}
 	return prevResult, currResult
 }

--- a/internal/logging/detailed_diff_logger_test.go
+++ b/internal/logging/detailed_diff_logger_test.go
@@ -116,6 +116,235 @@ func TestGetMinimalDifferenceListChange(t *testing.T) {
 	g.Expect(currDiff).To(gomega.Equal(map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{"a", "b"}}}))
 }
 
+func TestGetMinimalDifferenceContainerImageChange(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	prev := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "app", "image": "app:v1"},
+		map[string]interface{}{"name": "sidecar", "image": "sidecar:v1"},
+	}}}}
+	curr := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "app", "image": "app:v2"},
+		map[string]interface{}{"name": "sidecar", "image": "sidecar:v1"},
+	}}}}
+	prevDiff, currDiff := logging.GetMinimalDifference(&manifest.Diff{Previous: prev, Current: curr})
+	g.Expect(prevDiff).To(gomega.Equal(map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "app", "image": "app:v1"},
+	}}}))
+	g.Expect(currDiff).To(gomega.Equal(map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "app", "image": "app:v2"},
+	}}}))
+}
+
+func TestGetMinimalDifferenceContainerAdded(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	prev := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "app", "image": "app:v1"},
+	}}}}
+	curr := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "app", "image": "app:v1"},
+		map[string]interface{}{"name": "sidecar", "image": "sidecar:v1"},
+	}}}}
+	prevDiff, currDiff := logging.GetMinimalDifference(&manifest.Diff{Previous: prev, Current: curr})
+	g.Expect(prevDiff).To(gomega.BeNil())
+	g.Expect(currDiff).To(gomega.Equal(map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "sidecar", "image": "sidecar:v1"},
+	}}}))
+}
+
+func TestGetMinimalDifferenceContainerRemoved(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	prev := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "app", "image": "app:v1"},
+		map[string]interface{}{"name": "sidecar", "image": "sidecar:v1"},
+	}}}}
+	curr := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "app", "image": "app:v1"},
+	}}}}
+	prevDiff, currDiff := logging.GetMinimalDifference(&manifest.Diff{Previous: prev, Current: curr})
+	g.Expect(prevDiff).To(gomega.Equal(map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "sidecar", "image": "sidecar:v1"},
+	}}}))
+	g.Expect(currDiff).To(gomega.BeNil())
+}
+
+func TestGetMinimalDifferenceMixedAnnotationAndContainerChange(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	makeManifest := func(gitRef, imageTag string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"example.com/service_git_ref": gitRef,
+							"checksum/config":             "abc123",
+						},
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "app",
+								"image": "example.com/app:" + imageTag,
+								"args":  []interface{}{"-target=app", "-log.level=info"},
+								"ports": []interface{}{
+									map[string]interface{}{"name": "http", "containerPort": int64(8080), "protocol": "TCP"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}}
+	}
+	prevDiff, currDiff := logging.GetMinimalDifference(&manifest.Diff{
+		Previous: makeManifest("abc1234", "abc1234"),
+		Current:  makeManifest("def5678", "def5678"),
+	})
+	g.Expect(prevDiff).To(gomega.Equal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"example.com/service_git_ref": "abc1234",
+					},
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{"name": "app", "image": "example.com/app:abc1234"},
+					},
+				},
+			},
+		},
+	}))
+	g.Expect(currDiff).To(gomega.Equal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"example.com/service_git_ref": "def5678",
+					},
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{"name": "app", "image": "example.com/app:def5678"},
+					},
+				},
+			},
+		},
+	}))
+}
+
+func TestGetMinimalDifferenceContainerImageOnlyChange(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	makeContainer := func(imageTag string) map[string]interface{} {
+		return map[string]interface{}{
+			"name":  "app",
+			"image": "example.com/app:" + imageTag,
+			"args":  []interface{}{"-config=/etc/app/config.yaml", "-target=app"},
+			"env": []interface{}{
+				map[string]interface{}{"name": "FOO", "value": "redacted"},
+				map[string]interface{}{"name": "BAR", "value": "redacted"},
+			},
+			"imagePullPolicy": "IfNotPresent",
+			"ports": []interface{}{
+				map[string]interface{}{"name": "http", "containerPort": int64(8080), "protocol": "TCP"},
+				map[string]interface{}{"name": "grpc", "containerPort": int64(9090), "protocol": "TCP"},
+			},
+			"resources": map[string]interface{}{
+				"limits":   map[string]interface{}{"cpu": "2", "memory": "4Gi"},
+				"requests": map[string]interface{}{"cpu": "1", "memory": "1Gi"},
+			},
+			"terminationMessagePath":   "/dev/termination-log",
+			"terminationMessagePolicy": "File",
+			"volumeMounts": []interface{}{
+				map[string]interface{}{"name": "scratch", "mountPath": "/data"},
+				map[string]interface{}{"name": "config", "mountPath": "/etc/app", "readOnly": true},
+			},
+		}
+	}
+	makeManifest := func(imageTag string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{makeContainer(imageTag)},
+					},
+				},
+			},
+		}}
+	}
+	prevDiff, currDiff := logging.GetMinimalDifference(&manifest.Diff{
+		Previous: makeManifest("abc1234"),
+		Current:  makeManifest("def5678"),
+	})
+	g.Expect(prevDiff).To(gomega.Equal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "app",
+							"image": "example.com/app:abc1234",
+						},
+					},
+				},
+			},
+		},
+	}))
+	g.Expect(currDiff).To(gomega.Equal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "app",
+							"image": "example.com/app:def5678",
+						},
+					},
+				},
+			},
+		},
+	}))
+}
+
+func TestGetMinimalDifferenceSliceReorderProducesNoDiff(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	prev := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "app", "image": "app:v1"},
+		map[string]interface{}{"name": "sidecar", "image": "sidecar:v1"},
+	}}}}
+	curr := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{"containers": []interface{}{
+		map[string]interface{}{"name": "sidecar", "image": "sidecar:v1"},
+		map[string]interface{}{"name": "app", "image": "app:v1"},
+	}}}}
+	prevDiff, currDiff := logging.GetMinimalDifference(&manifest.Diff{Previous: prev, Current: curr})
+	g.Expect(prevDiff).To(gomega.BeNil())
+	g.Expect(currDiff).To(gomega.BeNil())
+}
+
+func TestGetMinimalDifferenceSliceWithoutMergeKeyStaysAtomic(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	prev := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{"rules": []interface{}{
+		map[string]interface{}{"host": "a.example.com", "path": "/a"},
+	}}}}
+	curr := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{"rules": []interface{}{
+		map[string]interface{}{"host": "a.example.com", "path": "/b"},
+	}}}}
+	prevDiff, currDiff := logging.GetMinimalDifference(&manifest.Diff{Previous: prev, Current: curr})
+	g.Expect(prevDiff).To(gomega.Equal(map[string]interface{}{"spec": map[string]interface{}{"rules": []interface{}{
+		map[string]interface{}{"host": "a.example.com", "path": "/a"},
+	}}}))
+	g.Expect(currDiff).To(gomega.Equal(map[string]interface{}{"spec": map[string]interface{}{"rules": []interface{}{
+		map[string]interface{}{"host": "a.example.com", "path": "/b"},
+	}}}))
+}
+
 func TestGetMinimalDifferenceComplexChange(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewWithT(t)


### PR DESCRIPTION
## Summary

- Introduce merge-key-based slice diffing (`diffSlices`, `diffSlicesByKey`) so that Kubernetes keyed lists (containers, env, ports, volumeMounts, etc.) produce minimal element-level diffs instead of showing the entire slice.
- Add a doc comment above `computeDiff` explaining the mutual recursion call structure between `computeDiff` → `diffSlices` → `diffSlicesByKey` → `computeDiff`, and the atomic fallback for slices without a recognized merge key.

## Test plan

- [x] `gofmt` passes
- [x] `golangci-lint run ./internal/logging/...` reports 0 issues
- [x] `go test ./internal/logging/...` passes (existing + new tests cover keyed slice diffing, reorder tolerance, unkeyed atomic fallback, and deeply nested changes)


Made with [Cursor](https://cursor.com)